### PR TITLE
商品詳細情報表示機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,10 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+    @product = Product.find(params[:id])
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -25,6 +25,6 @@ class ProductsController < ApplicationController
   private
 
   def product_params
-    params.require(:product).permit(:image, :name, :discription, :category, :status, :delivery_chaege, :shipping_area, :shipping_day, :price, :user).merge(user_id: current_user.id)
+    params.require(:product).permit(:image, :name, :discription, :category_id, :status_id, :delivery_chaege_id, :shipping_area_id, :shipping_day_id, :price, :user).merge(user_id: current_user.id)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,10 @@
 class Product < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :category
+  belongs_to_active_hash :status
+  belongs_to_active_hash :delivery_chaege
+  belongs_to_active_hash :shipping_area
+  belongs_to_active_hash :shipping_day
   has_one :purchase
   belongs_to :user
   has_one_attached :image
@@ -7,11 +13,11 @@ class Product < ApplicationRecord
     validates :image
     validates :name
     validates :discription
-    validates :category
-    validates :status
-    validates :delivery_chaege
-    validates :shipping_area
-    validates :shipping_day
+    validates :category_id
+    validates :status_id
+    validates :delivery_chaege_id
+    validates :shipping_area_id
+    validates :shipping_day_id
     validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'この金額は入力できません' }
     validates :user
   end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
       <% @product.each do |product| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to product_path(product.id) do %>
           <div class='item-img-content'>
             <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -47,12 +47,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, Category.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:status, Status.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -68,17 +68,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_chaege, DeliveryChaege.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_chaege_id, DeliveryChaege.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_area, ShippingArea.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area_id, ShippingArea.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_day, ShippingDay.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {include_blank: "--"}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -31,7 +31,7 @@
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% else %>
+    <% elsif @product.purchase.present? == false %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,11 +7,13 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag , class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <%# <% if @product.purchase.present?%> %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <%# <% end %> %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,18 +7,18 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag , class:"item-box-img" %>
+      <%= image_tag @product.image,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <%# <% if @product.purchase.present?%> %>
+      <% if @product.purchase.present?%>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>
-      <%# <% end %> %>
+      <% end %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @product.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -26,45 +26,46 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if user_signed_in? && current_user.id == @product.user_id%>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% else %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.discription %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.delivery_chaege.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'products#index'
-  resources :products, only: [:index, :new, :create]
+  resources :products, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20200821030330_create_products.rb
+++ b/db/migrate/20200821030330_create_products.rb
@@ -1,15 +1,15 @@
 class CreateProducts < ActiveRecord::Migration[6.0]
   def change
     create_table :products do |t|
-      t.string :name,             null: false
-      t.text :discription,        null: false
-      t.integer :category,        null: false
-      t.integer :status,          null: false
-      t.integer :delivery_chaege, null: false
-      t.integer :shipping_area,   null: false
-      t.integer :shipping_day,    null: false
-      t.integer :price,           null: false
-      t.references :user,         null: false, foreign_key: true
+      t.string :name,                null: false
+      t.text :discription,           null: false
+      t.integer :category_id,        null: false
+      t.integer :status_id,          null: false
+      t.integer :delivery_chaege_id, null: false
+      t.integer :shipping_area_id,   null: false
+      t.integer :shipping_day_id,    null: false
+      t.integer :price,              null: false
+      t.references :user,            null: false, foreign_key: true
       t.timestamps
     end
   end


### PR DESCRIPTION
#what
商品の詳細ページ実装
#why
購入したい商品の情報を表示するため


ログアウト状態で商品詳細ページが見える
https://gyazo.com/bf5e765da208ca1b32ef2374b57359b9

出品者のみ編集・削除リンクを表示
https://gyazo.com/777ba6c71a3327f489bae2d90f774e3d

出品者以外（かつログインしたユーザー）のみ商品購入リンクが踏める
https://gyazo.com/32e89051ba241147b0cab70143ab054a

売り切れたものの画像表示と購入リンクの非表示
https://gyazo.com/e2aa5041fcf653bd124b32a4a6b19d46